### PR TITLE
write traces to tempo

### DIFF
--- a/K8s/helm/templates/otel-collector-config.yaml
+++ b/K8s/helm/templates/otel-collector-config.yaml
@@ -29,7 +29,7 @@ data:
         asserts_server:
           endpoint: {{ .Values.otelcollector.assertsServer }}
           user: {{ .Values.otelcollector.assertsUser }}
-          password: {{ .Values.otelcollector.assertsPassword }}
+          password: ${env:ASSERTS_PASSWORD}
         asserts_env: {{ .Values.otelcollector.assertsEnv }}
         asserts_site: {{ .Values.otelcollector.assertsSite }}
         trace_rate_limit_per_service_per_request: {{ .Values.otelcollector.tracesPerRequest }}

--- a/K8s/helm/templates/otel-collector-config.yaml
+++ b/K8s/helm/templates/otel-collector-config.yaml
@@ -19,6 +19,10 @@ data:
         endpoint: http://jaeger.monitoring.svc.cluster.local:4317
         tls:
           insecure: true
+      otlp/tempo:
+        endpoint: tempo-dev-01-dev-us-central-0.grafana.net:443
+        headers:
+          authorization: Basic ${env:TEMPO_TOKEN}
 
     processors:
       assertsprocessor:
@@ -92,7 +96,7 @@ data:
         traces:
           receivers: [otlp]
           processors: [groupbytrace, assertsprocessor]
-          exporters: [otlp]
+          exporters: [otlp, otlp/tempo]
         metrics:
           receivers: [otlp]
           exporters: [prometheus]

--- a/K8s/helm/templates/otel-collector-deployment.yaml
+++ b/K8s/helm/templates/otel-collector-deployment.yaml
@@ -26,6 +26,8 @@ spec:
           envFrom:
           - secretRef:
               name: grafana-dev-tempo
+          - secretRef:
+              name: asserts-password-otel
           image: {{ .Values.image.repo }}/otel-collector:{{ .Values.image.otelcollectorVersion }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/K8s/helm/templates/otel-collector-deployment.yaml
+++ b/K8s/helm/templates/otel-collector-deployment.yaml
@@ -23,6 +23,9 @@ spec:
         - name: docker-hub
       containers:
         - name: otel-collector
+          envFrom:
+          - secretRef:
+              name: grafana-dev-tempo
           image: {{ .Values.image.repo }}/otel-collector:{{ .Values.image.otelcollectorVersion }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/K8s/helm/values.yaml
+++ b/K8s/helm/values.yaml
@@ -13,7 +13,7 @@ image:
   shippingVersion: "1.0.17"
   userVersion: "1.0.4"
   webVersion: "1.0.2"
-  otelcollectorVersion: "v0.0.93"
+  otelcollectorVersion: "v0.0.94"
   pullPolicy: IfNotPresent
 
 # Payment gateway URL


### PR DESCRIPTION
@shanavazh , I added the password which was on the cluster to be used as an envVar in the otel-collector so it is all up to date with GH versioning. 